### PR TITLE
Remove T: Ord requirement on Iterator impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,6 @@ impl<L, R, T> Iterator for MergeIter<L, R, T>
 where
     L: Iterator<Item = T>,
     R: Iterator<Item = T>,
-    T: Ord,
 {
     type Item = T;
 
@@ -221,6 +220,16 @@ mod tests {
         let merger = merger.collect::<Vec<_>>();
         assert_eq!(expected, merger);
         assert!(is_sorted(merger.iter()));
+    }
+
+    #[test]
+    fn test_merge_unord() {
+        struct UnOrd;
+
+        let a = vec![UnOrd];
+        let b = vec![UnOrd];
+        let merger = MergeIter::with_custom_ordering(a, b, |_, _| true);
+        let _ = merger.collect::<Vec<_>>();
     }
 
     fn is_sorted<I, T>(iter: I) -> bool


### PR DESCRIPTION
Hi,

first off: Thanks for making this! It's pretty much exactly what I need to merge `syn::Generics` instances.
However, there's one small issue that stops this crate from being really useful to me: The `Iterator` impl currently still requires `T: Ord`.

I assume you just forgot to delete the clause after adding `with_custom_ordering`, so here's a pull request that does that and adds a test to make sure `MergeIter` is useful on arbitrary types. I tried to match the existing test style, so please tell me if it feels off.

Thanks in advance for your consideration.